### PR TITLE
Fix assignment of Inode # to Path

### DIFF
--- a/filesystem/ninep.go
+++ b/filesystem/ninep.go
@@ -67,7 +67,7 @@ func fileInfoToQID(d os.FileInfo) stub.QID {
 	// on systems with inodes, use it.
 	if sysif != nil {
 		stat := sysif.(*syscall.Stat_t)
-		qid.Path = stat.Ino
+		qid.Path = uint64(stat.Ino)
 	} else {
 		qid.Path = uint64(d.ModTime().UnixNano())
 	}


### PR DESCRIPTION
We need to cast the inode # because on some systems it's only 32 bits.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>