### PR TITLE
use the right syntax for build tags

### DIFF
--- a/protocol/pprof.go
+++ b/protocol/pprof.go
@@ -1,6 +1,6 @@
-package protocol
-
 // +build pprof
+
+package protocol
 
 import (
 	"log"


### PR DESCRIPTION
This was getting included every build.  Oops.