### PR TITLE
filesystem: correctly return an error when a walk element fails.

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -128,7 +128,7 @@ func (e FileServer) Rwalk(fid protocol.FID, newfid protocol.FID, paths []string)
 		p = path.Join(p, paths[i])
 		st, err := os.Lstat(p)
 		if err != nil {
-			return q[:i], nil
+			return q[:i], fmt.Errorf("file does not exist")
 		}
 		q[i] = fileInfoToQID(st)
 	}

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -106,8 +106,8 @@ func TestMount(t *testing.T) {
 
 	t.Logf("Attach is %v", a)
 	w, err := c.CallTwalk(0, 1, []string{"hi", "there"})
-	if err != nil {
-		t.Fatalf("CallTwalk(0,1,[\"hi\", \"there\"]): want nil, got %v", err)
+	if err == nil {
+		t.Fatalf("CallTwalk(0,1,[\"hi\", \"there\"]): want err, got nil")
 	}
 	if len(w) > 0 {
 		t.Fatalf("CallTwalk(0,1,[\"hi\", \"there\"]): want 0 QIDs, got %v", w)


### PR DESCRIPTION
If a client walks a/b/c the server must return an array of QIDS
for all three elements. If the walk fails at any point the
server must return an error as well as an array of as many
QIDS as it was able to walk.

Example: if only a/b exists, and the client tries to walk
a/b/c, the server must return the QIDs for a and b as well
as an error.

Somehow I forgot this. This fixes a problem we'd seen in harvey
that was not a harvey problem. #294.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>