### PR TITLE
filesystem: return an array of QIDS one longer than the last successful walk

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -128,7 +128,30 @@ func (e FileServer) Rwalk(fid protocol.FID, newfid protocol.FID, paths []string)
 		p = path.Join(p, paths[i])
 		st, err := os.Lstat(p)
 		if err != nil {
-			return q[:i], fmt.Errorf("file does not exist")
+			// From the RFC: If the first element cannot
+			// be walked for any reason, Rerror is
+			// returned. Otherwise, the walk will return an
+			// Rwalk message containing nwqid qids
+			// corresponding, in order, to the files that
+			// are visited by the nwqid successful
+			// elementwise walks; nwqid is therefore either
+			// nwname or the index of the first elementwise
+			// walk that failed. The value of nwqid cannot
+			// be zero unless nwname is zero. Also, nwqid
+			// will always be less than or equal to
+			// nwname. Only if it is equal, however, will
+			// newfid be affected, in which case newfid
+			// will represent the file reached by the final
+			// elementwise walk requested in the message.
+			//
+			// to sum up: if any walks have succeeded, you
+			// return the QIDS for one more than the last successful walk
+			if i == 0 {
+				return nil, fmt.Errorf("file does not exist")
+			}
+			// we only get here if i is > 0 and less than nwname,
+			// so the i + 1 should be safe.
+			return q[:i+1], fmt.Errorf("file does not exist")
 		}
 		q[i] = fileInfoToQID(st)
 	}

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-    "github.com/Harvey-OS/ninep/protocol"
+	"github.com/Harvey-OS/ninep/protocol"
 )
 
 func print(f string, args ...interface{}) {


### PR DESCRIPTION
For as long as I've been writing 9p servers (20 years now, oh joy)
I thought a walk that ended in an
error should only return the number of QIDs successfully walked. Oops.
It needs to return one more, the last one being invalid;
unless the number is zero, in which case it should return error and no
QIDS.

This fixes an error message printing problem seen in harvey.

So far, the score is harvey 3, Go servers 0, when it comes to correctness in 9p :-)
This server has had two errors so far, found in simple ls commands.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>