### PR TITLE
USER: Set a default user of harvey and provide a -u switch

### DIFF
--- a/filesystem/ninep.go
+++ b/filesystem/ninep.go
@@ -7,10 +7,15 @@
 package ufs
 
 import (
+	"flag"
 	"os"
 	"syscall"
 
 	"github.com/Harvey-OS/ninep/protocol"
+)
+
+var (
+	user = flag.String("user", "harvey", "Default user name")
 )
 
 func OModeToUnixFlags(mode protocol.Mode) int {
@@ -108,8 +113,8 @@ func dirTo9p2000Dir(fi os.FileInfo) (*protocol.Dir, error) {
 	d.Mtime = uint32(fi.ModTime().Unix())
 	d.Length = uint64(fi.Size())
 	d.Name = fi.Name()
-	d.User = "root"
-	d.Group = "root"
+	d.User = *user
+	d.Group = *user
 
 	return d, nil
 }


### PR DESCRIPTION
This is the reason rio failed. I still don't see why it was so pervasive,
i.e. ramfs -m /mnt still did not fix the problem, but I guess there's magic
in mount I still don't understand.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>