### PR TITLE
wstat: do not do a rename if the target is a directory

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -295,6 +295,13 @@ func (e FileServer) Rwstat(fid protocol.FID, b []byte) error {
 			newname = path.Join(e.rootPath, dir.Name)
 		}
 
+		// If to exists, and to is a directory, we can't do the
+		// rename, since os.Rename will move from into to.
+
+		st, err := os.Stat(newname)
+		if err == nil && st.IsDir() {
+			return fmt.Errorf("is a directory")
+		}
 		if err := os.Rename(f.fullName, newname); err != nil {
 			return err
 		}


### PR DESCRIPTION
This resolves a failure seen with 321c312d of the golang
code. It checked to make sure that a rename of a directory
to a directory failed, since Unix kernel basically move the
source directory into the destination; plan 9 semantics requires
that the old directory not exist.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>