### PR TITLE
Tflush: correct the definition of the struct

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -98,7 +98,7 @@ func (e FileServer) Rattach(fid protocol.FID, afid protocol.FID, uname string, a
 	return r.QID, nil
 }
 
-func (e FileServer) Rflush(f protocol.FID, t protocol.FID) error {
+func (e FileServer) Rflush(o protocol.Tag) error {
 	return nil
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -199,8 +199,7 @@ type RattachPkt struct {
 }
 
 type TflushPkt struct {
-	RFID FID
-	OFID FID
+	OTag Tag
 }
 
 type RflushPkt struct {
@@ -358,7 +357,7 @@ type NineServer interface {
 	Rremove(FID) error
 	Rread(FID, Offset, Count) ([]byte, error)
 	Rwrite(FID, Offset, []byte) (Count, error)
-	Rflush(FID, FID) error
+	Rflush(Otag Tag) error
 }
 
 var (

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -221,13 +221,13 @@ func (e *echo) Rattach(FID, FID, string, string) (QID, error) {
 	return QID{}, nil
 }
 
-func (e *echo) Rflush(f FID, t FID) error {
-	switch int(f) {
-	case 2:
+func (e *echo) Rflush(o Tag) error {
+	switch o {
+	case 3:
 		// Make it fancier, later.
 		return nil
 	}
-	return fmt.Errorf("Read: bad FID %v", f)
+	return fmt.Errorf("Rflush: bad Tag %v", o)
 }
 
 func (e *echo) Rwalk(fid FID, newfid FID, paths []string) ([]QID, error) {
@@ -483,11 +483,11 @@ func TestTMessages(t *testing.T) {
 	if err := c.CallTwstat(FID(1), []byte{}); err == nil {
 		t.Fatalf("CallTwstat: want err, got nil")
 	}
-	if err := c.CallTflush(FID(2), FID(3)); err != nil {
+	if err := c.CallTflush(3); err != nil {
 		t.Fatalf("CallTflush: want nil, got %v", err)
 	}
 
-	if err := c.CallTflush(FID(1), FID(3)); err == nil {
+	if err := c.CallTflush(2); err == nil {
 		t.Fatalf("CallTflush: want err, got nil")
 	}
 }


### PR DESCRIPTION
You call Tflush with a tag, not two FIDS!

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>