### PR TITLE
Make the debug service more general to allow debugging of other servers

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -41,7 +41,6 @@ type FileServer struct {
 }
 
 var (
-	debug = flag.Int("debug", 0, "print debug messages")
 	root  = flag.String("root", "/", "Set the root for all attaches")
 )
 
@@ -450,8 +449,8 @@ func NewUFS(opts ...protocol.ServerOpt) (*protocol.Server, error) {
 	f.rootPath = *root // for now.
 	// any opts for the ufs layer can be added here too ...
 	var d protocol.NineServer = f
-	if *debug != 0 {
-		d = &debugFileServer{f}
+	if *protocol.Debug {
+		d = &protocol.DebugServer{f}
 	}
 	s, err := protocol.NewServer(d, opts...)
 	if err != nil {

--- a/protocol/debug.go
+++ b/protocol/debug.go
@@ -2,22 +2,25 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package ufs
+package protocol
 
 import (
 	"bytes"
+        "flag"
 	"log"
-
-	"github.com/Harvey-OS/ninep/protocol"
 )
 
-type debugFileServer struct {
-	*FileServer
+var (
+        Debug = flag.Bool("debug", false, "print debug messages")
+)
+
+type DebugServer struct {
+	NineServer
 }
 
-func (e *debugFileServer) Rversion(msize protocol.MaxSize, version string) (protocol.MaxSize, string, error) {
+func (e *DebugServer) Rversion(msize MaxSize, version string) (MaxSize, string, error) {
 	log.Printf(">>> Tversion %v %v\n", msize, version)
-	msize, version, err := e.FileServer.Rversion(msize, version)
+	msize, version, err := e.NineServer.Rversion(msize, version)
 	if err == nil {
 		log.Printf("<<< Rversion %v %v\n", msize, version)
 	} else {
@@ -26,10 +29,10 @@ func (e *debugFileServer) Rversion(msize protocol.MaxSize, version string) (prot
 	return msize, version, err
 }
 
-func (e *debugFileServer) Rattach(fid protocol.FID, afid protocol.FID, uname string, aname string) (protocol.QID, error) {
+func (e *DebugServer) Rattach(fid FID, afid FID, uname string, aname string) (QID, error) {
 	log.Printf(">>> Tattach fid %v,  afid %v, uname %v, aname %v\n", fid, afid,
 		uname, aname)
-	qid, err := e.FileServer.Rattach(fid, afid, uname, aname)
+	qid, err := e.NineServer.Rattach(fid, afid, uname, aname)
 	if err == nil {
 		log.Printf("<<< Rattach %v\n", qid)
 	} else {
@@ -38,9 +41,9 @@ func (e *debugFileServer) Rattach(fid protocol.FID, afid protocol.FID, uname str
 	return qid, err
 }
 
-func (e *debugFileServer) Rflush(o protocol.Tag) error {
+func (e *DebugServer) Rflush(o Tag) error {
 	log.Printf(">>> Tflush tag %v\n", o)
-	err := e.FileServer.Rflush(o)
+	err := e.NineServer.Rflush(o)
 	if err == nil {
 		log.Printf("<<< Rflush\n")
 	} else {
@@ -49,9 +52,9 @@ func (e *debugFileServer) Rflush(o protocol.Tag) error {
 	return err
 }
 
-func (e *debugFileServer) Rwalk(fid protocol.FID, newfid protocol.FID, paths []string) ([]protocol.QID, error) {
+func (e *DebugServer) Rwalk(fid FID, newfid FID, paths []string) ([]QID, error) {
 	log.Printf(">>> Twalk fid %v, newfid %v, paths %v\n", fid, newfid, paths)
-	qid, err := e.FileServer.Rwalk(fid, newfid, paths)
+	qid, err := e.NineServer.Rwalk(fid, newfid, paths)
 	if err == nil {
 		log.Printf("<<< Rwalk %v\n", qid)
 	} else {
@@ -60,9 +63,9 @@ func (e *debugFileServer) Rwalk(fid protocol.FID, newfid protocol.FID, paths []s
 	return qid, err
 }
 
-func (e *debugFileServer) Ropen(fid protocol.FID, mode protocol.Mode) (protocol.QID, protocol.MaxSize, error) {
+func (e *DebugServer) Ropen(fid FID, mode Mode) (QID, MaxSize, error) {
 	log.Printf(">>> Topen fid %v, mode %v\n", fid, mode)
-	qid, iounit, err := e.FileServer.Ropen(fid, mode)
+	qid, iounit, err := e.NineServer.Ropen(fid, mode)
 	if err == nil {
 		log.Printf("<<< Ropen %v %v\n", qid, iounit)
 	} else {
@@ -71,10 +74,10 @@ func (e *debugFileServer) Ropen(fid protocol.FID, mode protocol.Mode) (protocol.
 	return qid, iounit, err
 }
 
-func (e *debugFileServer) Rcreate(fid protocol.FID, name string, perm protocol.Perm, mode protocol.Mode) (protocol.QID, protocol.MaxSize, error) {
+func (e *DebugServer) Rcreate(fid FID, name string, perm Perm, mode Mode) (QID, MaxSize, error) {
 	log.Printf(">>> Tcreate fid %v, name %v, perm %v, mode %v\n", fid, name,
 		perm, mode)
-	qid, iounit, err := e.FileServer.Rcreate(fid, name, perm, mode)
+	qid, iounit, err := e.NineServer.Rcreate(fid, name, perm, mode)
 	if err == nil {
 		log.Printf("<<< Rcreate %v %v\n", qid, iounit)
 	} else {
@@ -83,9 +86,9 @@ func (e *debugFileServer) Rcreate(fid protocol.FID, name string, perm protocol.P
 	return qid, iounit, err
 }
 
-func (e *debugFileServer) Rclunk(fid protocol.FID) error {
+func (e *DebugServer) Rclunk(fid FID) error {
 	log.Printf(">>> Tclunk fid %v\n", fid)
-	err := e.FileServer.Rclunk(fid)
+	err := e.NineServer.Rclunk(fid)
 	if err == nil {
 		log.Printf("<<< Rclunk\n")
 	} else {
@@ -94,11 +97,11 @@ func (e *debugFileServer) Rclunk(fid protocol.FID) error {
 	return err
 }
 
-func (e *debugFileServer) Rstat(fid protocol.FID) ([]byte, error) {
+func (e *DebugServer) Rstat(fid FID) ([]byte, error) {
 	log.Printf(">>> Tstat fid %v\n", fid)
-	b, err := e.FileServer.Rstat(fid)
+	b, err := e.NineServer.Rstat(fid)
 	if err == nil {
-		dir, _ := protocol.Unmarshaldir(bytes.NewBuffer(b))
+		dir, _ := Unmarshaldir(bytes.NewBuffer(b))
 		log.Printf("<<< Rstat %v\n", dir)
 	} else {
 		log.Printf("<<< Error %v\n", err)
@@ -106,10 +109,10 @@ func (e *debugFileServer) Rstat(fid protocol.FID) ([]byte, error) {
 	return b, err
 }
 
-func (e *debugFileServer) Rwstat(fid protocol.FID, b []byte) error {
-	dir, _ := protocol.Unmarshaldir(bytes.NewBuffer(b))
+func (e *DebugServer) Rwstat(fid FID, b []byte) error {
+	dir, _ := Unmarshaldir(bytes.NewBuffer(b))
 	log.Printf(">>> Twstat fid %v, %v\n", fid, dir)
-	err := e.FileServer.Rwstat(fid, b)
+	err := e.NineServer.Rwstat(fid, b)
 	if err == nil {
 		log.Printf("<<< Rwstat\n")
 	} else {
@@ -118,9 +121,9 @@ func (e *debugFileServer) Rwstat(fid protocol.FID, b []byte) error {
 	return err
 }
 
-func (e *debugFileServer) Rremove(fid protocol.FID) error {
+func (e *DebugServer) Rremove(fid FID) error {
 	log.Printf(">>> Tremove fid %v\n", fid)
-	err := e.FileServer.Rremove(fid)
+	err := e.NineServer.Rremove(fid)
 	if err == nil {
 		log.Printf("<<< Rremove\n")
 	} else {
@@ -129,9 +132,9 @@ func (e *debugFileServer) Rremove(fid protocol.FID) error {
 	return err
 }
 
-func (e *debugFileServer) Rread(fid protocol.FID, o protocol.Offset, c protocol.Count) ([]byte, error) {
+func (e *DebugServer) Rread(fid FID, o Offset, c Count) ([]byte, error) {
 	log.Printf(">>> Tread fid %v, off %v, count %v\n", fid, o, c)
-	b, err := e.FileServer.Rread(fid, o, c)
+	b, err := e.NineServer.Rread(fid, o, c)
 	if err == nil {
 		log.Printf("<<< Rread %v\n", len(b))
 	} else {
@@ -140,9 +143,9 @@ func (e *debugFileServer) Rread(fid protocol.FID, o protocol.Offset, c protocol.
 	return b, err
 }
 
-func (e *debugFileServer) Rwrite(fid protocol.FID, o protocol.Offset, b []byte) (protocol.Count, error) {
+func (e *DebugServer) Rwrite(fid FID, o Offset, b []byte) (Count, error) {
 	log.Printf(">>> Twrite fid %v, off %v, count %v\n", fid, o, len(b))
-	c, err := e.FileServer.Rwrite(fid, o, b)
+	c, err := e.NineServer.Rwrite(fid, o, b)
 	if err == nil {
 		log.Printf("<<< Rwrite %v\n", c)
 	} else {


### PR DESCRIPTION
I am making my own file server using this library and found that the debugging was useful for implementing it. The existing filesystem debug server was relatively easy to abstract.