### PR TITLE
One Server per connection

### DIFF
--- a/cmd/ufs/ufs.go
+++ b/cmd/ufs/ufs.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/Harvey-OS/ninep/filesystem"
+	ufs "github.com/Harvey-OS/ninep/filesystem"
 	"github.com/Harvey-OS/ninep/protocol"
 )
 
@@ -26,12 +26,12 @@ func main() {
 		log.Fatalf("Listen failed: %v", err)
 	}
 
-	s, err := ufs.NewUFS(func(s *protocol.Server) error {
-		s.Trace = nil // log.Printf
+	ufslistener, err := ufs.NewUFS(func(l *protocol.Listener) error {
+		l.Trace = nil // log.Printf
 		return nil
 	})
 
-	if err := s.Serve(ln); err != nil {
+	if err := ufslistener.Serve(ln); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -442,21 +442,23 @@ func (e *FileServer) Rwrite(fid protocol.FID, o protocol.Offset, b []byte) (prot
 	return protocol.Count(n), err
 }
 
-type ServerOpt func(*protocol.Server) error
-
-func NewUFS(opts ...protocol.ServerOpt) (*protocol.Server, error) {
-	f := &FileServer{}
-	f.files = make(map[protocol.FID]*file)
-	f.rootPath = *root // for now.
-	// any opts for the ufs layer can be added here too ...
-	var d protocol.NineServer = f
-	if *debug != 0 {
-		d = &debugFileServer{f}
+func NewUFS(opts ...protocol.ListenerOpt) (*protocol.Listener, error) {
+	nsCreator := func() protocol.NineServer {
+		f := &FileServer{}
+		f.files = make(map[protocol.FID]*file)
+		f.rootPath = *root // for now.
+		f.IOunit = 8192
+		// any opts for the ufs layer can be added here too ...
+		var d protocol.NineServer = f
+		if *debug != 0 {
+			d = &debugFileServer{f}
+		}
+		return d
 	}
-	s, err := protocol.NewServer(d, opts...)
+
+	l, err := protocol.NewListener(nsCreator, opts...)
 	if err != nil {
 		return nil, err
 	}
-	f.IOunit = 8192
-	return s, nil
+	return l, nil
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -291,7 +291,7 @@ type RPCReply struct {
 
 /* rpc servers */
 type ClientOpt func(*Client) error
-type ServerOpt func(*Server) error
+type ListenerOpt func(*Listener) error
 type Tracer func(string, ...interface{})
 
 type NineServer interface {


### PR DESCRIPTION
Recent changes meant that there is only one Server (and therefore one fid->file map) per connection.  This doesn't work if a connection is dropped then reconnects and tries to use the same fids (since they were never removed).

This change tries to break up the Server struct into:
- Listener to handle connections (not a great name...)
- Server to handle server state per connection

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>