### PR TITLE
Rread: handle the case where the count is too small for the entry

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -408,6 +408,13 @@ func (e *FileServer) Rread(fid protocol.FID, o protocol.Offset, c protocol.Count
 				return nil, err
 			}
 			protocol.Marshaldir(b, *d9p)
+			// Seen on linux clients: sometimes the math is wrong and
+			// they end up asking for the last element with not enough data.
+			// Linux bug or bug with this server? Not sure yet.
+			if b.Len() > int(c) {
+				log.Printf("Warning: Server bug? %v, need %d bytes;count is %d: skipping", d9p, b.Len(), c)
+				return nil, nil
+			}
 			// We're not quite doing the array right.
 			// What does work is returning one thing so, for now, do that.
 			return b.Bytes(), nil


### PR DESCRIPTION
We are seeing cases where a readdir, for the last element, is called with a count
too small for the element.

There's not much to do when this happens, save print a log message that the element
is being skipped.

Sadly, this means a directory listing will not be complete.

Directory reading in this server sucks anyway, see the comment, I hope someone will fix.

We need a test to cause this case, but I could not quite figure out how to do it.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>